### PR TITLE
Remove Faraday requirement in gemspec

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,6 @@ PATH
   remote: .
   specs:
     regent (0.3.4)
-      faraday (~> 2.12)
       pastel (~> 0.8.0)
       tty-spinner (~> 0.9.3)
       zeitwerk (~> 2.7)
@@ -56,7 +55,6 @@ GEM
       faraday (~> 2.0)
       typhoeus (~> 1.4)
     ffi (1.17.0)
-    ffi (1.17.0-arm64-darwin)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake

--- a/lib/regent.rb
+++ b/lib/regent.rb
@@ -2,7 +2,6 @@
 
 require 'securerandom'
 require 'json'
-require 'faraday'
 require 'pastel'
 require 'tty-spinner'
 require 'zeitwerk'

--- a/lib/regent/llm.rb
+++ b/lib/regent/llm.rb
@@ -34,7 +34,7 @@ module Regent
 
       provider.invoke(messages, **args)
 
-    rescue Faraday::Error, ApiError => error
+    rescue StandardError => error
       if error.respond_to?(:retryable?) && error.retryable? && retries < DEFAULT_RETRY_COUNT
         sleep(exponential_backoff(retries))
         retry

--- a/lib/regent/llm/ollama.rb
+++ b/lib/regent/llm/ollama.rb
@@ -6,6 +6,8 @@ module Regent
       # Default host for Ollama API.
       DEFAULT_HOST = "http://localhost:11434"
 
+      depends_on "faraday"
+
       def initialize(model:, host: nil, **options)
         @model = model
         @host = host || DEFAULT_HOST

--- a/regent.gemspec
+++ b/regent.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |spec|
 
   # Uncomment to register a new dependency of your gem
   # spec.add_dependency "example-gem", "~> 1.0"
-  spec.add_dependency "faraday", "~> 2.12"
   spec.add_dependency "zeitwerk", "~> 2.7"
   spec.add_dependency "tty-spinner", "~> 0.9.3"
   spec.add_dependency "pastel", "~> 0.8.0"


### PR DESCRIPTION
This removes `faraday` as an explicit gem requirement. Many of the client gems will require Faraday, that's fine, but doing this means that you won't get clashes with other versions of Faraday you might have in your Gemfile.

(An alternative would be to keep the gemspec dep but remove the version constraint. I think this is better.)